### PR TITLE
🐛 regions-updater: Fix Dockerfile

### DIFF
--- a/regions-updater/Dockerfile
+++ b/regions-updater/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 # Copy the go source.
 COPY main.go main.go
 COPY types.go types.go
+COPY sort.go sort.go
 
 # Build, based on the architecture we want this to run.
 # Define GOOS=linux GOARCH=arch when building for a different architecture.


### PR DESCRIPTION
This PR fixes an error in Regions Updater Dockerfile not including `sort.go` file.